### PR TITLE
Fix sporadic test_stdout_only_drain trace race

### DIFF
--- a/tests/_support/output_forwarding.py
+++ b/tests/_support/output_forwarding.py
@@ -1,5 +1,6 @@
 import io
 import os
+import time
 import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -29,6 +30,7 @@ class OutputForwardingTimings:
     child_tick_count: int
     child_tick_delay: float
     child_termination_delay: float
+    trace_settle_delay: float | None = None
 
 
 @dataclass
@@ -84,6 +86,10 @@ class OutputForwardingRunner:
             command_error = exc
             fate = exc.fate
         output = bin_output.getvalue().decode(encoding="utf-8")
+        if timing.trace_settle_delay is not None:
+            # Some tests need a pause before checking trace files created
+            # by detached child processes.
+            time.sleep(timing.trace_settle_delay)
         return _OutputForwardingAttempt(
             fate=fate,
             output_probe=output_probe,

--- a/tests/runner/test_output_drain.py
+++ b/tests/runner/test_output_drain.py
@@ -228,6 +228,9 @@ def test_stdout_only_drain(
                 child_tick_delay=1.0,
                 child_tick_count=5,
                 child_termination_delay=2,
+                # note: we need time for the detached child process to write
+                # DESCENDANT_RELEASED_STDO event
+                trace_settle_delay=3,
             )
         ],
         present_events=[


### PR DESCRIPTION
Add an optional trace-settle delay for output-forwarding timing profiles and use it in test_stdout_only_drain.

The test waits for DESCENDANT_RELEASED_STDO, which is written by the detached child process after stdio is closed. flnr may already have returned after observing pipe EOF, so the trace file can appear slightly after the run completes.